### PR TITLE
Add interactive BOM link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Pin header and sockets are compatible with
 The board can be used with [PMI-BOB2](https://github.com/emtpb/pmi-hw-bob2)
 pcb.
 
-An interactive html BOM file with pcb layout and material placement can be
-found [here](bom/ibom.html).
+# Interactive BOM
+
+An interactive html BOM page with pcb layout and material placement can be found [here](https://emtpb.github.io/pmi-hw-dan/bom/ibom.html).
 
 # Changelog
 


### PR DESCRIPTION
This pull request adds a GitHub Pages link to the interactive bill of materials (BOM) in the README.